### PR TITLE
调整京东金融钢镚链接

### DIFF
--- a/JD-DailyBonus/JD_DailyBonus.js
+++ b/JD-DailyBonus/JD_DailyBonus.js
@@ -598,7 +598,7 @@ function JingRongSteel(s) {
     if (disable("JRSteel")) return resolve()
     setTimeout(() => {
       const JRSUrl = {
-        url: 'https://ms.jr.jd.com/gw/generic/gry/h5/m/signIn',
+        url: 'https://ms.jr.jd.com/gw/generic/gry/h5/m/signIn1',
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
           Cookie: KEY,


### PR DESCRIPTION
有连签挑战活动时要调用signIn1，平时调用signIn。看后期是否可以优化判断调用哪个接口