### PR TITLE
Update CamScanner Expire Time

### DIFF
--- a/Surge/JS/CamScanner.js
+++ b/Surge/JS/CamScanner.js
@@ -30,5 +30,5 @@ hostname = ap*.intsig.net
 
 **************************/
 let obj = JSON.parse($response.body);
-obj = {"data":{"psnl_vip_property":{"expiry":"1643731200"}}};
+obj = {"data":{"psnl_vip_property":{"expiry":"1687017600"}}};
 $done({body: JSON.stringify(obj)});


### PR DESCRIPTION
The reason for the membership lapse is that it has expired (22 Feb 2022) and I have changed it to expire on 18 Jun 2023.