### PR TITLE
$loon的输出不再支持上述代码，因此这里只能删除

### DIFF
--- a/Shortcuts/PolicySwitch.js
+++ b/Shortcuts/PolicySwitch.js
@@ -36,7 +36,7 @@ const body = JSON.parse($request.body || '{}');
 })()
 
 function nobyda() {
-	const isLoon = typeof($loon) !== "undefined" && $loon > 289;
+	const isLoon = typeof($loon) !== "undefined";
 	const isQuanX = typeof($configuration) !== 'undefined';
 	const isSurge = typeof($httpAPI) !== 'undefined';
 	const m = `不支持您的APP版本, 请等待APP更新 ⚠️`;


### PR DESCRIPTION
如题，现今的$loon命令的输出是完整的版本号，包括设备版本和软件完整版本，$loon>289的结果始终为False，无法支持现版本loon的使用，只能选择删除